### PR TITLE
Fix sidebar template reference

### DIFF
--- a/src/Sidebar.gs
+++ b/src/Sidebar.gs
@@ -1,5 +1,5 @@
 const SIDEBAR_TITLE = 'Panel de pruebas';
-const SIDEBAR_TEMPLATES = ['SidebarMain', 'Sidebar'];
+const SIDEBAR_TEMPLATES = ['Sidebar'];
 const FALLBACK_SIDEBAR_HTML = `<!DOCTYPE html>
 <html lang="es">
   <head>
@@ -144,6 +144,3 @@ function logNoteOnRow(note) {
   };
 }
 
-function include(filename) {
-  return HtmlService.createHtmlOutputFromFile(filename).getContent();
-}

--- a/src/SidebarMain.html
+++ b/src/SidebarMain.html
@@ -1,1 +1,0 @@
-<?!= include('Sidebar'); ?>


### PR DESCRIPTION
## Summary
- update the sidebar loader to target only the Sidebar template
- remove the unused wrapper template that triggered missing file errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690bd65518488323a5a27df8783145b3