### PR TITLE
Improve sidebar loading robustness and UI feedback

### DIFF
--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -2,6 +2,7 @@
 <html lang="es">
   <head>
     <meta charset="utf-8" />
+    <base target="_top" />
     <title>Panel de pruebas</title>
     <style>
       body {
@@ -63,7 +64,10 @@
         margin-top: 8px;
         color: #0f5132;
       }
-      .error {
+      .status[aria-live] {
+        min-height: 18px;
+      }
+      .status.error {
         color: #b91c1c;
       }
     </style>
@@ -75,6 +79,7 @@
     <div class="section">
       <h2>Fila activa</h2>
       <button id="fetch-row" onclick="fetchActiveRow()">Consultar</button>
+      <p id="row-status" class="status" aria-live="polite"></p>
       <pre id="row-result">Sin datos todavía…</pre>
     </div>
 
@@ -82,41 +87,49 @@
       <h2>Notas rápidas</h2>
       <textarea id="note" placeholder="Escribe una nota para la celda activa..."></textarea>
       <button class="secondary" id="save-note" onclick="saveNote()">Guardar nota</button>
-      <p id="note-status" class="status"></p>
+      <p id="note-status" class="status" aria-live="polite"></p>
     </div>
 
     <script>
       function fetchActiveRow() {
         setLoading(true);
+        setStatus('Consultando fila activa…', { targetId: 'row-status' });
         google.script.run
           .withSuccessHandler((data) => {
             const content = JSON.stringify(data, null, 2);
             document.getElementById('row-result').textContent = content;
-            setStatus('Fila recuperada correctamente.');
+            setStatus('Fila recuperada correctamente.', { targetId: 'row-status' });
             setLoading(false);
           })
-          .withFailureHandler(handleError)
+          .withFailureHandler((error) => handleError(error, 'row-status'))
           .getActiveRowData();
       }
 
       function saveNote() {
         const note = document.getElementById('note').value.trim();
         if (!note) {
-          setStatus('Debes escribir una nota antes de guardar.', true);
+          setStatus('Debes escribir una nota antes de guardar.', { isError: true });
           return;
         }
         setLoading(true);
+        setStatus('Guardando nota…');
         google.script.run
           .withSuccessHandler((info) => {
             setStatus(`Nota guardada en fila ${info.row}, columna ${info.column}.`);
+            document.getElementById('note').value = '';
             setLoading(false);
           })
           .withFailureHandler(handleError)
           .logNoteOnRow(note);
       }
 
-      function setStatus(message, isError = false) {
-        const label = document.getElementById('note-status');
+      function setStatus(message, options = {}) {
+        const { targetId = 'note-status', isError = false } = options;
+        const label = document.getElementById(targetId);
+        if (!label) {
+          console.warn('Elemento de estado no encontrado:', targetId);
+          return;
+        }
         label.textContent = message;
         label.className = isError ? 'status error' : 'status';
       }
@@ -126,9 +139,12 @@
         document.getElementById('save-note').disabled = value;
       }
 
-      function handleError(error) {
+      function handleError(error, targetId = 'note-status') {
         console.error(error);
-        setStatus(error.message || 'Ocurrió un error inesperado.', true);
+        setStatus(error && error.message ? error.message : 'Ocurrió un error inesperado.', {
+          targetId,
+          isError: true,
+        });
         setLoading(false);
       }
     </script>

--- a/src/Sidebar.html
+++ b/src/Sidebar.html
@@ -74,7 +74,7 @@
   </head>
   <body>
     <h1>Panel de pruebas</h1>
-    <p>Hoja activa: <strong><?= sheetName ?></strong></p>
+    <p>Hoja activa: <strong id="sheet-name" aria-live="polite">Cargando…</strong></p>
 
     <div class="section">
       <h2>Fila activa</h2>
@@ -91,6 +91,25 @@
     </div>
 
     <script>
+      document.addEventListener('DOMContentLoaded', initializeSidebar);
+
+      function initializeSidebar() {
+        google.script.run
+          .withSuccessHandler(updateSheetName)
+          .withFailureHandler((error) => {
+            console.error(error);
+            updateSheetName('No disponible');
+          })
+          .getActiveSheetName();
+      }
+
+      function updateSheetName(name) {
+        const label = document.getElementById('sheet-name');
+        if (label) {
+          label.textContent = name || 'Sin nombre';
+        }
+      }
+
       function fetchActiveRow() {
         setLoading(true);
         setStatus('Consultando fila activa…', { targetId: 'row-status' });


### PR DESCRIPTION
## Summary
- make the sidebar loader resilient by normalizing template names, trying case variants, and providing an informative inline fallback view
- sanitize error details rendered inside the fallback panel to avoid HTML injection and highlight the missing template name clearly
- enhance the sidebar HTML with live status areas, better loading feedback, and automatic note field reset after saving

## Testing
- not run (Apps Script project)


------
https://chatgpt.com/codex/tasks/task_e_690d1854464c83238475b53858bcffd9